### PR TITLE
Add OPDS feed PRDs

### DIFF
--- a/docs/product/opds-feeds/01-prd-opds-api-key.md
+++ b/docs/product/opds-feeds/01-prd-opds-api-key.md
@@ -1,0 +1,52 @@
+# PRD: OPDS API Key Storage
+
+## Introduction/Overview
+Add an optional OPDS API key field to the users table so OPDS clients can authenticate via a URL-based key when Basic Auth is unreliable. This is a schema-only, additive change.
+
+## Goals
+- Add a nullable, unique OPDS API key column to users.
+- Keep all existing authentication flows unchanged.
+- Provide a schema foundation for later key generation and UI display.
+
+## User Stories
+
+### US-001: Add OPDS API key column
+**Description:** As a developer, I want a nullable `opds_api_key` column on `users` so we can store per-user OPDS API keys.
+
+**Acceptance Criteria:**
+- [ ] Update `src/lib/db/schema.ts` to include `opdsApiKey` as a nullable unique text column.
+- [ ] Generate a migration that adds the column without backfilling data.
+- [ ] Existing users remain valid with `opds_api_key` set to NULL.
+- [ ] Typecheck/lint passes.
+
+### US-002: Surface OPDS API key in ORM types
+**Description:** As a developer, I want the ORM types to include `opdsApiKey` so OPDS features can read/write it.
+
+**Acceptance Criteria:**
+- [ ] The generated types expose `opdsApiKey` on the user model.
+- [ ] No runtime behavior changes occur outside OPDS features.
+- [ ] Typecheck/lint passes.
+
+## Functional Requirements
+1. Add `opds_api_key` to `users` as nullable and unique.
+2. The migration must be additive and non-destructive.
+3. No existing login, session, or authorization logic is modified.
+
+## Non-Goals
+- No API key generation or regeneration logic.
+- No OPDS authentication behavior changes.
+- No UI changes.
+
+## Design Considerations
+- None.
+
+## Technical Considerations
+- Use Drizzle schema and migration tooling.
+- Keep the column nullable to avoid generating keys for unused accounts.
+
+## Success Metrics
+- Migration applies cleanly in dev and CI.
+- New code can read/write `opdsApiKey` without affecting existing users.
+
+## Open Questions
+- Should we add a separate index beyond the unique constraint, or rely on the unique index alone?

--- a/docs/product/opds-feeds/02-prd-opds-auth-middleware.md
+++ b/docs/product/opds-feeds/02-prd-opds-auth-middleware.md
@@ -1,0 +1,62 @@
+# PRD: OPDS Authentication Middleware
+
+## Introduction/Overview
+Implement a shared authentication helper for OPDS endpoints that supports HTTP Basic Auth and a per-user API key embedded in the URL path. This is additive and independent of NextAuth sessions.
+
+## Goals
+- Authenticate OPDS requests via API key or Basic Auth.
+- Keep OPDS auth isolated from session-based web auth.
+- Provide a consistent contract for OPDS route handlers.
+
+## User Stories
+
+### US-001: Authenticate via API key param
+**Description:** As a developer, I want OPDS routes to accept an `apiKey` path param so clients without Basic Auth support can authenticate.
+
+**Acceptance Criteria:**
+- [ ] `authenticateOpdsRequest(request, { apiKey })` looks up a user by `opdsApiKey`.
+- [ ] Missing or invalid keys return `null`.
+- [ ] Typecheck/lint passes.
+
+### US-002: Authenticate via HTTP Basic Auth
+**Description:** As a developer, I want OPDS routes to validate `Authorization: Basic` credentials against the users table.
+
+**Acceptance Criteria:**
+- [ ] Basic credentials are parsed into `email` and `password`.
+- [ ] Password validation uses bcrypt against the stored hash.
+- [ ] Invalid or missing credentials return `null`.
+- [ ] Typecheck/lint passes.
+
+### US-003: Consistent unauthorized behavior contract
+**Description:** As a developer, I want a clear contract that `null` means the caller should return `401 Unauthorized` with `WWW-Authenticate: Basic realm="Alex"`.
+
+**Acceptance Criteria:**
+- [ ] The helper returns `User | null` only.
+- [ ] Callers can unambiguously detect unauthorized requests.
+- [ ] Typecheck/lint passes.
+
+## Functional Requirements
+1. Provide `authenticateOpdsRequest(request, params?)` in `src/lib/opds/auth.ts`.
+2. If `params.apiKey` is provided, attempt API key auth first.
+3. If API key auth fails, attempt Basic Auth from the `Authorization` header.
+4. On any failure, return `null` without throwing or logging credentials.
+5. Do not create sessions, cookies, or JWTs.
+
+## Non-Goals
+- OAuth, Digest auth, or token refresh flows.
+- Credential caching or rate limiting.
+- Changes to existing NextAuth or API auth logic.
+
+## Design Considerations
+- Keep the function stateless and safe to call per request.
+
+## Technical Considerations
+- Handle malformed Base64 or missing `:` gracefully.
+- Avoid leaking credentials in logs or error messages.
+
+## Success Metrics
+- A valid API key or Basic Auth pair yields an authenticated user in manual testing.
+- Invalid credentials consistently yield `401` responses from OPDS routes.
+
+## Open Questions
+- Do we want a short-lived in-memory cache for bcrypt checks, or defer until performance is a concern?

--- a/docs/product/opds-feeds/03-prd-opds-xml-builder.md
+++ b/docs/product/opds-feeds/03-prd-opds-xml-builder.md
@@ -1,0 +1,69 @@
+# PRD: OPDS XML Builder Utilities
+
+## Introduction/Overview
+Create helper utilities to generate well-formed OPDS 1.2 Atom XML for navigation feeds, acquisition feeds, book entries, and OpenSearch descriptions. This centralizes XML formatting and escaping.
+
+## Goals
+- Produce consistent, valid OPDS 1.2 XML across routes.
+- Ensure all text content is safely XML-escaped.
+- Make feed construction easy and reusable.
+
+## User Stories
+
+### US-001: Build navigation feeds
+**Description:** As a developer, I want `buildNavigationFeed` to generate a navigation feed with entries linking to sub-feeds.
+
+**Acceptance Criteria:**
+- [ ] The function returns a full `<feed>` document string.
+- [ ] Required Atom and OPDS namespaces are present on the root element.
+- [ ] Entries include `title`, `id`, and `updated` fields.
+- [ ] Typecheck/lint passes.
+
+### US-002: Build acquisition feeds with pagination and facets
+**Description:** As a developer, I want `buildAcquisitionFeed` to generate an acquisition feed with book entries and pagination links.
+
+**Acceptance Criteria:**
+- [ ] The function accepts entries, `self`, `start`, and optional `next` or `previous` links.
+- [ ] The output includes acquisition entries and optional facet links.
+- [ ] Typecheck/lint passes.
+
+### US-003: Build a book entry
+**Description:** As a developer, I want `buildEntry` to generate a single OPDS entry with acquisition and cover links.
+
+**Acceptance Criteria:**
+- [ ] The entry includes title, id, updated, author, and optional description and language.
+- [ ] Acquisition link uses `http://opds-spec.org/acquisition/open-access`.
+- [ ] Cover and thumbnail links are included when available.
+- [ ] Typecheck/lint passes.
+
+### US-004: Build OpenSearch description
+**Description:** As a developer, I want `buildOpenSearchDescription` to generate the OpenSearch XML document for OPDS search discovery.
+
+**Acceptance Criteria:**
+- [ ] The output uses `application/opensearchdescription+xml` compatible structure.
+- [ ] The search URL template includes `{searchTerms}`.
+- [ ] Typecheck/lint passes.
+
+## Functional Requirements
+1. Add `src/lib/opds/xml.ts` with `buildNavigationFeed`, `buildAcquisitionFeed`, `buildEntry`, and `buildOpenSearchDescription`.
+2. Root `<feed>` includes the Atom, OPDS, Dublin Core, OpenSearch, and Threading namespaces.
+3. All user-supplied text values are XML-escaped.
+4. All `href` values accept absolute-path URLs (starting with `/`).
+
+## Non-Goals
+- OPDS 2.0 (JSON) generation.
+- XML parsing or validation libraries.
+- Any changes to existing book metadata extraction.
+
+## Design Considerations
+- Prefer a small, readable template-literal builder over a heavy XML library.
+
+## Technical Considerations
+- Include a shared XML-escape helper for `<`, `>`, `&`, `"`, and `'`.
+- Ensure date fields are ISO-8601 strings.
+
+## Success Metrics
+- Sample feeds render correctly in an OPDS client without XML parsing errors.
+
+## Open Questions
+- Should facet link creation live in the XML helper or in route handlers?

--- a/docs/product/opds-feeds/04-prd-opds-authenticated-routes.md
+++ b/docs/product/opds-feeds/04-prd-opds-authenticated-routes.md
@@ -1,0 +1,99 @@
+# PRD: Authenticated OPDS Routes (v1.2)
+
+## Introduction/Overview
+Add authenticated OPDS 1.2 endpoints that expose the full library and collections as Atom feeds, plus book download and cover endpoints. This is read-only and additive.
+
+## Goals
+- Provide OPDS navigation and acquisition feeds for authenticated users.
+- Support both Basic Auth and API key authentication.
+- Reuse existing data access and file-serving logic without changing core behavior.
+
+## User Stories
+
+### US-001: Catalog root navigation feed
+**Description:** As a user, I want a root OPDS catalog feed so my client can discover library sections.
+
+**Acceptance Criteria:**
+- [ ] `GET /opds/v1.2/catalog` returns a navigation feed with links to All Books, Recently Added, and Collections.
+- [ ] The feed includes `self`, `start`, and `search` links.
+- [ ] The response uses the navigation content type.
+- [ ] Typecheck/lint passes.
+
+### US-002: All books acquisition feed
+**Description:** As a user, I want a paginated acquisition feed of all books so I can browse large libraries.
+
+**Acceptance Criteria:**
+- [ ] `GET /opds/v1.2/all?page=N` returns books ordered by title.
+- [ ] Page size defaults to 50 with `next` or `previous` links when applicable.
+- [ ] Facet links include sort (title, author, recently added) and format filters (PDF, EPUB).
+- [ ] Typecheck/lint passes.
+
+### US-003: Recently added feed
+**Description:** As a user, I want a feed of recently added books so I can quickly find new items.
+
+**Acceptance Criteria:**
+- [ ] `GET /opds/v1.2/new` returns the latest 50 books ordered by `addedAt` desc.
+- [ ] The response uses the acquisition content type.
+- [ ] Typecheck/lint passes.
+
+### US-004: Collections navigation and collection feeds
+**Description:** As a user, I want to browse my collections and their books in OPDS.
+
+**Acceptance Criteria:**
+- [ ] `GET /opds/v1.2/collections` returns a navigation feed of my collections.
+- [ ] `GET /opds/v1.2/collections/{id}` returns a paginated acquisition feed for that collection.
+- [ ] Collection access is validated against the authenticated user.
+- [ ] Typecheck/lint passes.
+
+### US-005: Search endpoints
+**Description:** As a user, I want OPDS search so I can find books by title or author.
+
+**Acceptance Criteria:**
+- [ ] `GET /opds/v1.2/search` returns an OpenSearch description document.
+- [ ] `GET /opds/v1.2/search?q=term` returns acquisition search results using existing search logic.
+- [ ] Typecheck/lint passes.
+
+### US-006: OPDS book file and cover endpoints
+**Description:** As a user, I want OPDS-specific file and cover URLs so my client can download and display books reliably.
+
+**Acceptance Criteria:**
+- [ ] `GET /opds/v1.2/books/{id}/file` authenticates and streams the book file.
+- [ ] `GET /opds/v1.2/books/{id}/cover` authenticates and streams the cover image with correct content type.
+- [ ] Endpoints reuse existing file or cover logic without altering it.
+- [ ] Typecheck/lint passes.
+
+### US-007: API key path variants
+**Description:** As a user, I want API-key-prefixed OPDS routes so clients without Basic Auth can access the catalog.
+
+**Acceptance Criteria:**
+- [ ] All authenticated OPDS routes work under `/opds/{apiKey}/v1.2/...`.
+- [ ] The API key variant uses the same handlers and XML output.
+- [ ] Typecheck/lint passes.
+
+## Functional Requirements
+1. Implement authenticated routes under `/opds/v1.2/` as described in the plan.
+2. Support both Basic Auth and API key authentication via the shared auth helper.
+3. Use XML builders for all feed responses.
+4. Set correct OPDS content types for navigation and acquisition feeds.
+5. Use absolute-path `href` values in all XML links.
+6. Reuse existing data queries and file or cover serving logic without modifying core behavior.
+7. Keep all OPDS endpoints read-only.
+
+## Non-Goals
+- OPDS 2.0 or JSON feeds.
+- Any write operations via OPDS.
+- Changes to existing `/api/books` or web UI behavior.
+
+## Design Considerations
+- Keep route handlers thin and rely on shared builders and helpers.
+
+## Technical Considerations
+- Ensure `WWW-Authenticate` header is set for unauthorized requests.
+- Consider a shared handler or catch-all to avoid code duplication for API key routes.
+
+## Success Metrics
+- OPDS clients can browse and download using both Basic Auth and API key URLs.
+- Feeds load without errors in at least one desktop and one mobile OPDS client.
+
+## Open Questions
+- Should the All Books feed be restricted to admins if per-user libraries are added later?

--- a/docs/product/opds-feeds/05-prd-opds-public-feeds.md
+++ b/docs/product/opds-feeds/05-prd-opds-public-feeds.md
@@ -1,0 +1,60 @@
+# PRD: Public OPDS Feeds for Shared Collections
+
+## Introduction/Overview
+Expose shared collections as public OPDS acquisition feeds accessible via existing share tokens. No authentication is required beyond the token.
+
+## Goals
+- Provide OPDS feeds for shared collections using existing share tokens.
+- Reuse current public share logic and file endpoints.
+- Keep public OPDS access read-only and scoped.
+
+## User Stories
+
+### US-001: Shared collection acquisition feed
+**Description:** As a visitor, I want to open an OPDS feed for a shared collection so I can browse its books.
+
+**Acceptance Criteria:**
+- [ ] `GET /opds/shared/{token}` returns an acquisition feed for the collection.
+- [ ] Invalid tokens return `404` without leaking information.
+- [ ] The feed uses the acquisition content type.
+- [ ] Typecheck/lint passes.
+
+### US-002: Shared collection search
+**Description:** As a visitor, I want OPDS search within a shared collection.
+
+**Acceptance Criteria:**
+- [ ] `GET /opds/shared/{token}/search` returns an OpenSearch description document.
+- [ ] `GET /opds/shared/{token}/search?q=term` returns acquisition results scoped to the collection.
+- [ ] Typecheck/lint passes.
+
+### US-003: Public file and cover links
+**Description:** As a visitor, I want book links to use the existing public endpoints so downloads and covers work reliably.
+
+**Acceptance Criteria:**
+- [ ] Acquisition links point to `/api/shared/{token}/books/{bookId}/file`.
+- [ ] Cover links point to `/api/shared/{token}/books/{bookId}/cover`.
+- [ ] Typecheck/lint passes.
+
+## Functional Requirements
+1. Implement `/opds/shared/{token}` and `/opds/shared/{token}/search` routes.
+2. Validate tokens using existing shared-collection helpers.
+3. Use XML builders and absolute-path links.
+4. Keep all public OPDS endpoints read-only and scoped to the token.
+
+## Non-Goals
+- Listing all shared collections.
+- Any authentication or session handling.
+- Changes to existing share token generation or revocation.
+
+## Design Considerations
+- Match the public web share behavior and visibility.
+
+## Technical Considerations
+- Ensure 404 on invalid or revoked tokens.
+- Keep content types consistent with OPDS 1.2.
+
+## Success Metrics
+- A valid share token produces an OPDS feed that downloads books successfully.
+
+## Open Questions
+- Should public feeds include collection-level metadata beyond the title, such as a description?

--- a/docs/product/opds-feeds/06-prd-opds-middleware-exempt.md
+++ b/docs/product/opds-feeds/06-prd-opds-middleware-exempt.md
@@ -1,0 +1,38 @@
+# PRD: OPDS Middleware Exemption
+
+## Introduction/Overview
+Ensure OPDS routes bypass NextAuth middleware so OPDS clients can authenticate using Basic Auth or API keys without session cookies.
+
+## Goals
+- Allow `/opds/` routes to pass through middleware untouched.
+- Keep all non-OPDS routes and auth flows unchanged.
+
+## User Stories
+
+### US-001: Bypass NextAuth for OPDS routes
+**Description:** As a developer, I want `/opds/` paths to skip NextAuth checks so OPDS auth can be handled by the OPDS routes.
+
+**Acceptance Criteria:**
+- [ ] `src/middleware.ts` returns `NextResponse.next()` early for paths starting with `/opds/`.
+- [ ] No other middleware behavior changes.
+- [ ] Typecheck/lint passes.
+
+## Functional Requirements
+1. Add an early `/opds/` path check in middleware.
+2. Keep all existing middleware logic intact for other routes.
+
+## Non-Goals
+- Any changes to session handling or protected routes outside `/opds/`.
+- New authentication methods for non-OPDS endpoints.
+
+## Design Considerations
+- Keep the change minimal and localized.
+
+## Technical Considerations
+- Ensure the check includes `/opds/shared/...` routes.
+
+## Success Metrics
+- OPDS endpoints no longer redirect to login or return NextAuth errors.
+
+## Open Questions
+- None.

--- a/docs/product/opds-feeds/07-prd-opds-settings-ui.md
+++ b/docs/product/opds-feeds/07-prd-opds-settings-ui.md
@@ -1,0 +1,75 @@
+# PRD: OPDS Settings UI
+
+## Introduction/Overview
+Add an OPDS section to the user settings page so users can find their catalog URL, manage an API key, and copy URLs into OPDS clients.
+
+## Goals
+- Make OPDS setup self-serve for users.
+- Allow API key generation and regeneration with confirmation.
+- Keep the settings change additive and consistent with existing UI.
+
+## User Stories
+
+### US-001: Display OPDS catalog URLs
+**Description:** As a user, I want to see my OPDS catalog URL so I can add it to a reading app.
+
+**Acceptance Criteria:**
+- [ ] Settings page shows the Basic Auth catalog URL (`/opds/v1.2/catalog`).
+- [ ] Settings page shows the API-key URL (`/opds/{apiKey}/v1.2/catalog`) with the key masked by default.
+- [ ] URLs are rendered as copyable text with a "Copy URL" action.
+- [ ] Typecheck/lint passes.
+- [ ] Verify in browser using dev-browser skill.
+
+### US-002: Generate and regenerate API keys
+**Description:** As a user, I want to generate or regenerate my OPDS API key so I can use clients that do not support Basic Auth.
+
+**Acceptance Criteria:**
+- [ ] If no key exists, a "Generate Key" action creates one and updates the display.
+- [ ] If a key exists, a "Regenerate Key" action requires confirmation and invalidates the prior key.
+- [ ] Key generation is server-side and tied to the current user.
+- [ ] Typecheck/lint passes.
+- [ ] Verify in browser using dev-browser skill.
+
+### US-003: Show or hide the API key
+**Description:** As a user, I want to toggle key visibility so I can copy it safely.
+
+**Acceptance Criteria:**
+- [ ] The API key is masked by default with a "Show" toggle.
+- [ ] Toggling reveals the full key and updates the URL display.
+- [ ] Typecheck/lint passes.
+- [ ] Verify in browser using dev-browser skill.
+
+### US-004: OPDS usage guidance
+**Description:** As a user, I want brief setup guidance so I can connect an OPDS client quickly.
+
+**Acceptance Criteria:**
+- [ ] The OPDS section includes short instructions for adding the URL in common OPDS apps.
+- [ ] Typecheck/lint passes.
+- [ ] Verify in browser using dev-browser skill.
+
+## Functional Requirements
+1. Add an OPDS section to `src/app/(dashboard)/settings/page.tsx`.
+2. Display both Basic Auth and API-key catalog URLs.
+3. Provide generate or regenerate actions with confirmation for regeneration.
+4. Mask the API key by default and allow a show or hide toggle.
+5. Do not alter other settings or authentication flows.
+
+## Non-Goals
+- An in-app OPDS client or reader.
+- Storing OPDS client credentials.
+- Changes to core user account management outside OPDS.
+
+## Design Considerations
+- Reuse existing settings layout, buttons, and confirmation dialog patterns.
+
+## Technical Considerations
+- Provide a server action or API route to create or regenerate `opdsApiKey`.
+- Ensure the action is protected to the current user only.
+- Avoid logging the API key in client or server logs.
+
+## Success Metrics
+- Users can copy a working OPDS URL in under 2 clicks.
+- Regenerating a key immediately invalidates the previous URL.
+
+## Open Questions
+- Should we provide a one-click "Copy API-key URL" and "Copy Basic URL" separately, or a single picker?

--- a/docs/product/opds-feeds/08-prd-opds-discovery-headers.md
+++ b/docs/product/opds-feeds/08-prd-opds-discovery-headers.md
@@ -1,0 +1,50 @@
+# PRD: OPDS Auto-Discovery Headers
+
+## Introduction/Overview
+Add OPDS auto-discovery link tags to HTML pages so OPDS clients and browsers can locate the catalog feed.
+
+## Goals
+- Publish the authenticated catalog link on general pages.
+- Publish shared collection feed links on shared collection pages.
+- Keep changes additive and invisible to end users.
+
+## User Stories
+
+### US-001: Add global OPDS discovery link
+**Description:** As a developer, I want the main layout to include an OPDS alternate link to the authenticated catalog.
+
+**Acceptance Criteria:**
+- [ ] `src/app/layout.tsx` includes a `<link rel="alternate">` tag for `/opds/v1.2/catalog`.
+- [ ] The `type` attribute is `application/atom+xml;profile=opds-catalog`.
+- [ ] Typecheck/lint passes.
+- [ ] Verify in browser using dev-browser skill.
+
+### US-002: Add shared collection discovery link
+**Description:** As a developer, I want shared collection pages to include an OPDS alternate link for their feed.
+
+**Acceptance Criteria:**
+- [ ] Pages rendering `/shared/{token}` include a `<link rel="alternate">` tag for `/opds/shared/{token}`.
+- [ ] The tag uses an appropriate `title` such as "Shared Collection".
+- [ ] Typecheck/lint passes.
+- [ ] Verify in browser using dev-browser skill.
+
+## Functional Requirements
+1. Add an OPDS discovery `<link>` tag in the main layout for the authenticated catalog.
+2. Add a discovery `<link>` tag for shared collection pages only.
+3. Use the OPDS 1.2 media type and stable titles.
+
+## Non-Goals
+- OPDS 2.0 discovery links.
+- Visible UI changes or user-facing copy changes.
+
+## Design Considerations
+- None.
+
+## Technical Considerations
+- Prefer absolute-path `href` values so the same markup works across environments.
+
+## Success Metrics
+- The discovery `<link>` tags are present in page HTML and match expected URLs.
+
+## Open Questions
+- Should discovery links use absolute URLs with origin, or keep relative paths?


### PR DESCRIPTION
Creates phase-based PRDs for OPDS feed support. Includes database, auth, XML, routes, public feeds, middleware exemption, settings UI, and discovery headers.