### PR TITLE
Redesign theme for literary aesthetic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ next-env.d.ts
 
 # local data (database, uploaded books)
 /data
+
+# test script
+bootstrap.sh

--- a/src/app/(dashboard)/admin/users/page.tsx
+++ b/src/app/(dashboard)/admin/users/page.tsx
@@ -19,9 +19,9 @@ export default async function UsersPage() {
     .orderBy(asc(users.createdAt));
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <div className="flex items-center justify-between gap-4">
-        <h1 className="text-lg font-semibold">User Management</h1>
+        <h1 className="text-lg font-medium tracking-tight">User Management</h1>
         <div id="users-table-actions" />
       </div>
       <UsersTable

--- a/src/app/(dashboard)/collections/[id]/collection-detail-client.tsx
+++ b/src/app/(dashboard)/collections/[id]/collection-detail-client.tsx
@@ -352,10 +352,10 @@ export default function CollectionDetailClient() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <h1 className="text-lg font-semibold">{collection.collection.name}</h1>
+          <h1 className="text-lg font-medium tracking-tight">{collection.collection.name}</h1>
           {collection.collection.description && (
             <p className="text-sm text-muted-foreground mt-1 max-w-2xl">
               {collection.collection.description}
@@ -435,7 +435,7 @@ export default function CollectionDetailClient() {
             <>
               <div className="space-y-4">
                 <h2 className="text-base font-semibold">Now Reading</h2>
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-5">
                   {nowReadingBooks.map((book) => (
                     <BookCard
                       key={book.id}

--- a/src/app/(dashboard)/collections/collections-client.tsx
+++ b/src/app/(dashboard)/collections/collections-client.tsx
@@ -111,9 +111,9 @@ export default function CollectionsClient() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <div className="flex items-center justify-between gap-4">
-        <h1 className="text-lg font-semibold">Collections</h1>
+        <h1 className="text-lg font-medium tracking-tight">Collections</h1>
         <Button
           type="button"
           variant="link"
@@ -189,7 +189,7 @@ export default function CollectionsClient() {
       </Dialog>
 
       {loading ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
           {Array.from({ length: 6 }).map((_, i) => (
             <Card key={i} className="gap-3">
               <CardHeader className="pb-1">
@@ -228,7 +228,7 @@ export default function CollectionsClient() {
           </p>
         </div>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
           {collections.map((collection) => (
             <Link key={collection.id} href={`/collections/${collection.id}`} className="group">
               <Card className="h-full">

--- a/src/app/(dashboard)/dashboard-layout.tsx
+++ b/src/app/(dashboard)/dashboard-layout.tsx
@@ -159,8 +159,8 @@ export default function DashboardLayout({
       )}
 
       {/* Header */}
-      <header className="flex h-10 shrink-0 items-center border-b border-border bg-sidebar text-sidebar-foreground px-3">
-        <div className="flex items-center gap-2 min-w-[160px]">
+      <header className="flex h-14 shrink-0 items-center border-b border-border bg-sidebar text-sidebar-foreground px-5">
+        <div className="flex items-center gap-3 min-w-[180px]">
           <button
             className="md:hidden text-sidebar-foreground"
             aria-label="Open sidebar"
@@ -181,7 +181,7 @@ export default function DashboardLayout({
             </svg>
           </button>
           <AppLogo className="shrink-0 text-sidebar-foreground" />
-          <span className="text-sm font-semibold">Alex</span>
+          <span className="text-sm font-medium tracking-wide">Alex</span>
         </div>
 
         <div className="flex-1 flex justify-center">
@@ -256,7 +256,7 @@ export default function DashboardLayout({
           )}
         </div>
 
-        <div className="flex items-center justify-end min-w-[160px]">
+        <div className="flex items-center justify-end min-w-[180px]">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -309,12 +309,12 @@ export default function DashboardLayout({
         {/* Sidebar */}
         <aside
           className={[
-            "fixed top-10 bottom-0 left-0 z-50 w-52 bg-sidebar border-r border-sidebar-border flex flex-col",
+            "fixed top-14 bottom-0 left-0 z-50 w-56 bg-sidebar border-r border-sidebar-border flex flex-col",
             sidebarOpen ? "translate-x-0" : "-translate-x-full",
             "md:relative md:translate-x-0 md:inset-y-0",
           ].join(" ")}
         >
-          <div className="md:hidden flex h-10 shrink-0 items-center justify-end px-3 border-b border-sidebar-border">
+          <div className="md:hidden flex h-14 shrink-0 items-center justify-end px-5 border-b border-sidebar-border">
             <button
               className="text-muted-foreground hover:text-foreground"
               aria-label="Close sidebar"
@@ -350,7 +350,7 @@ export default function DashboardLayout({
                   return (
                     <div
                       key={item.href}
-                      className="flex items-center gap-3 px-3 py-2 text-sm font-medium text-muted-foreground opacity-60 cursor-not-allowed border-b border-border border-l-2 border-transparent"
+                      className="flex items-center gap-3 px-5 py-3 text-sm font-medium text-muted-foreground opacity-60 cursor-not-allowed border-l-2 border-transparent"
                     >
                       {item.icon}
                       <span className="flex-1">{item.label}</span>
@@ -367,9 +367,9 @@ export default function DashboardLayout({
                     href={item.href}
                     onClick={() => setSidebarOpen(false)}
                     className={[
-                      "flex items-center gap-3 px-3 py-2 text-sm font-medium border-b border-border border-l-2",
+                      "flex items-center gap-3 px-5 py-3 text-sm font-medium border-l-2",
                       isActive
-                        ? "border-primary bg-muted font-semibold text-foreground"
+                        ? "border-primary bg-muted font-medium text-foreground"
                         : "border-transparent text-muted-foreground hover:bg-muted hover:text-foreground",
                     ].join(" ")}
                   >
@@ -385,7 +385,7 @@ export default function DashboardLayout({
         {/* Main area */}
         <div className="flex-1 flex flex-col min-w-0">
           {/* Page content */}
-          <main className="flex-1 overflow-auto p-4">{children}</main>
+          <main className="flex-1 overflow-auto p-6 md:p-8">{children}</main>
         </div>
       </div>
     </div>

--- a/src/app/(dashboard)/library/library-client.tsx
+++ b/src/app/(dashboard)/library/library-client.tsx
@@ -219,8 +219,8 @@ export default function LibraryClient() {
   };
 
   return (
-    <div className="space-y-6">
-      <h1 className="text-lg font-semibold">Library</h1>
+    <div className="space-y-8">
+      <h1 className="text-lg font-medium tracking-tight">Library</h1>
 
       {/* Library update banner */}
       {libraryUpdateDetected && (
@@ -277,11 +277,11 @@ export default function LibraryClient() {
 
       {/* Grid / Skeleton / Empty */}
       {loading ? (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-5">
           {Array.from({ length: 8 }).map((_, i) => (
-            <div key={i} className="border overflow-hidden">
+            <div key={i} className="overflow-hidden">
               <Skeleton className="aspect-[2/3]" />
-              <div className="p-2 space-y-2">
+              <div className="pt-2.5 space-y-2">
                 <Skeleton className="h-4 w-3/4" />
                 <Skeleton className="h-3 w-1/2" />
               </div>
@@ -326,9 +326,9 @@ export default function LibraryClient() {
           {/* Now Reading section */}
           {nowReadingBooks.length > 0 && (
             <>
-              <div className="space-y-4">
-                <h2 className="text-base font-semibold">Now Reading</h2>
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+              <div className="space-y-5">
+                <h2 className="text-base font-medium">Now Reading</h2>
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-5">
                   {nowReadingBooks.map((book) => (
                     <BookCard key={book.id} book={book} />
                   ))}
@@ -353,7 +353,7 @@ export default function LibraryClient() {
                 {otherBooks.length > 0 && (
                   <>
                     <div className="grid grid-cols-1 sm:grid-cols-2">
-                      <h2 className="text-base font-semibold">All Books</h2>
+                      <h2 className="text-base font-medium">All Books</h2>
                       {!loading && (
                         <p className="text-sm text-muted-foreground text-end">
                           Showing {books.length} of {total}{" "}
@@ -362,7 +362,7 @@ export default function LibraryClient() {
                       )}
                     </div>
 
-                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-5">
                       {otherBooks.map((book) => (
                         <BookCard key={book.id} book={book} />
                       ))}
@@ -378,11 +378,11 @@ export default function LibraryClient() {
 
           {/* Loading more skeletons */}
           {isLoadingMore && (
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-5">
               {Array.from({ length: 4 }).map((_, i) => (
-                <div key={i} className="border overflow-hidden">
+                <div key={i} className="overflow-hidden">
                   <Skeleton className="aspect-[2/3]" />
-                  <div className="p-2 space-y-2">
+                  <div className="pt-2.5 space-y-2">
                     <Skeleton className="h-4 w-3/4" />
                     <Skeleton className="h-3 w-1/2" />
                   </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -61,72 +61,72 @@ body {
 }
 
 :root {
-  --radius: 0px;
+  --radius: 8px;
   --background: #FFFFFF;
-  --foreground: #000000;
+  --foreground: #1A1A1A;
   --card: #FFFFFF;
-  --card-foreground: #000000;
+  --card-foreground: #1A1A1A;
   --popover: #FFFFFF;
-  --popover-foreground: #000000;
-  --primary: #000000;
+  --popover-foreground: #1A1A1A;
+  --primary: #1A1A1A;
   --primary-foreground: #FFFFFF;
-  --secondary: #E6E6E6;
-  --secondary-foreground: #000000;
-  --muted: #E6E6E6;
-  --muted-foreground: #3A3A3A;
-  --accent: #E6E6E6;
-  --accent-foreground: #000000;
-  --destructive: #000000;
-  --border: #E6E6E6;
-  --input: #E6E6E6;
-  --ring: #000000;
-  --chart-1: #000000;
-  --chart-2: #3A3A3A;
-  --chart-3: #E6E6E6;
-  --chart-4: #000000;
-  --chart-5: #3A3A3A;
+  --secondary: #F5F5F3;
+  --secondary-foreground: #1A1A1A;
+  --muted: #F5F5F3;
+  --muted-foreground: #878787;
+  --accent: #F5F5F3;
+  --accent-foreground: #1A1A1A;
+  --destructive: #B91C1C;
+  --border: #EBEBEB;
+  --input: #E2E2E0;
+  --ring: #1A1A1A;
+  --chart-1: #1A1A1A;
+  --chart-2: #878787;
+  --chart-3: #EBEBEB;
+  --chart-4: #1A1A1A;
+  --chart-5: #878787;
   --sidebar: #FFFFFF;
-  --sidebar-foreground: #000000;
-  --sidebar-primary: #000000;
+  --sidebar-foreground: #1A1A1A;
+  --sidebar-primary: #1A1A1A;
   --sidebar-primary-foreground: #FFFFFF;
-  --sidebar-accent: #E6E6E6;
-  --sidebar-accent-foreground: #000000;
-  --sidebar-border: #E6E6E6;
-  --sidebar-ring: #000000;
+  --sidebar-accent: #F5F5F3;
+  --sidebar-accent-foreground: #1A1A1A;
+  --sidebar-border: #EBEBEB;
+  --sidebar-ring: #1A1A1A;
 }
 
 .dark {
-  --background: #000000;
-  --foreground: #FFFFFF;
-  --card: #000000;
-  --card-foreground: #FFFFFF;
-  --popover: #000000;
-  --popover-foreground: #FFFFFF;
-  --primary: #FFFFFF;
-  --primary-foreground: #000000;
-  --secondary: #3A3A3A;
-  --secondary-foreground: #FFFFFF;
-  --muted: #3A3A3A;
-  --muted-foreground: #E6E6E6;
-  --accent: #3A3A3A;
-  --accent-foreground: #FFFFFF;
-  --destructive: #FFFFFF;
-  --border: #3A3A3A;
-  --input: #3A3A3A;
-  --ring: #FFFFFF;
-  --chart-1: #FFFFFF;
-  --chart-2: #E6E6E6;
-  --chart-3: #3A3A3A;
-  --chart-4: #FFFFFF;
-  --chart-5: #E6E6E6;
-  --sidebar: #000000;
-  --sidebar-foreground: #FFFFFF;
-  --sidebar-primary: #FFFFFF;
-  --sidebar-primary-foreground: #000000;
-  --sidebar-accent: #3A3A3A;
-  --sidebar-accent-foreground: #FFFFFF;
-  --sidebar-border: #3A3A3A;
-  --sidebar-ring: #FFFFFF;
+  --background: #0F0F0F;
+  --foreground: #E8E8E6;
+  --card: #0F0F0F;
+  --card-foreground: #E8E8E6;
+  --popover: #161616;
+  --popover-foreground: #E8E8E6;
+  --primary: #E8E8E6;
+  --primary-foreground: #0F0F0F;
+  --secondary: #1E1E1C;
+  --secondary-foreground: #E8E8E6;
+  --muted: #1E1E1C;
+  --muted-foreground: #888886;
+  --accent: #1E1E1C;
+  --accent-foreground: #E8E8E6;
+  --destructive: #EF4444;
+  --border: #2A2A28;
+  --input: #2A2A28;
+  --ring: #E8E8E6;
+  --chart-1: #E8E8E6;
+  --chart-2: #888886;
+  --chart-3: #2A2A28;
+  --chart-4: #E8E8E6;
+  --chart-5: #888886;
+  --sidebar: #0F0F0F;
+  --sidebar-foreground: #E8E8E6;
+  --sidebar-primary: #E8E8E6;
+  --sidebar-primary-foreground: #0F0F0F;
+  --sidebar-accent: #1E1E1C;
+  --sidebar-accent-foreground: #E8E8E6;
+  --sidebar-border: #2A2A28;
+  --sidebar-ring: #E8E8E6;
 }
 
 @layer base {
@@ -142,6 +142,6 @@ body {
   }
   body {
     @apply bg-background text-foreground;
-    font-family: var(--font-ibm-plex-sans), sans-serif;
+    font-family: var(--font-hanken-grotesk), sans-serif;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,13 @@
 import type { Metadata } from "next";
 import Script from "next/script";
-import { IBM_Plex_Mono, IBM_Plex_Sans } from "next/font/google";
+import { Hanken_Grotesk, IBM_Plex_Mono } from "next/font/google";
 import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
 
-const ibmPlexSans = IBM_Plex_Sans({
-  variable: "--font-ibm-plex-sans",
+const hankenGrotesk = Hanken_Grotesk({
+  variable: "--font-hanken-grotesk",
   subsets: ["latin"],
-  weight: ["400", "500", "600"],
+  weight: ["300", "400", "500", "600"],
 });
 
 const ibmPlexMono = IBM_Plex_Mono({
@@ -50,7 +50,7 @@ export default function RootLayout({
           }}
         />
       </head>
-      <body className={`${ibmPlexSans.variable} ${ibmPlexMono.variable}`}>
+      <body className={`${hankenGrotesk.variable} ${ibmPlexMono.variable}`}>
         {children}
         <Toaster />
       </body>

--- a/src/app/shared/[token]/not-found.tsx
+++ b/src/app/shared/[token]/not-found.tsx
@@ -15,7 +15,7 @@ export default function NotFound() {
         <line x1="8" y1="8" x2="16" y2="16" />
         <line x1="16" y1="8" x2="8" y2="16" />
       </svg>
-      <h1 className="text-lg font-semibold mb-2">Collection Not Found</h1>
+      <h1 className="text-lg font-medium tracking-tight mb-2">Collection Not Found</h1>
       <p className="text-muted-foreground max-w-md">
         This collection doesn&apos;t exist or is no longer shared. Please check
         the link and try again.

--- a/src/app/shared/[token]/shared-collection-client.tsx
+++ b/src/app/shared/[token]/shared-collection-client.tsx
@@ -87,7 +87,7 @@ export default function SharedCollectionClient({
       {/* Collection metadata */}
       <div className="space-y-3">
         <div className="flex items-start gap-3">
-          <h1 className="text-lg font-semibold flex-1">{collection.name}</h1>
+          <h1 className="text-lg font-medium tracking-tight flex-1">{collection.name}</h1>
           <Badge variant="secondary" className="text-sm">
             Shared Collection
           </Badge>

--- a/src/components/library/BookCard.tsx
+++ b/src/components/library/BookCard.tsx
@@ -131,7 +131,7 @@ export function BookCard({
   return (
     <Link
       href={`/read/${book.id}`}
-      className="group block border bg-card overflow-hidden"
+      className="group block overflow-hidden"
       onClick={(event) => {
         if (collectionsOpen) {
           event.preventDefault();
@@ -140,7 +140,7 @@ export function BookCard({
       }}
     >
       {/* Cover */}
-      <div className="relative aspect-[2/3] overflow-hidden bg-muted border-b border-border">
+      <div className="relative aspect-[2/3] overflow-hidden bg-muted rounded-sm">
         <img
           src={`/api/books/${book.id}/cover?t=${book.updatedAt}`}
           alt={book.title}
@@ -149,9 +149,9 @@ export function BookCard({
       </div>
 
       {/* Info */}
-      <div className="p-2 space-y-1">
+      <div className="pt-2.5 space-y-1">
         <div className="flex items-start gap-2">
-          <h3 className="flex-1 font-medium text-sm leading-tight line-clamp-2">
+          <h3 className="flex-1 font-normal text-sm leading-tight line-clamp-2">
             {book.title}
           </h3>
           <Button
@@ -189,11 +189,11 @@ export function BookCard({
             {book.author}
           </p>
         )}
-        <p className="text-sm text-muted-foreground">
+        <p className="text-xs text-muted-foreground">
           {metadata}
         </p>
         {book.readingProgress?.status === "completed" && (
-          <p className="text-sm text-muted-foreground font-medium">
+          <p className="text-xs text-muted-foreground font-medium">
             Completed
           </p>
         )}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center border border-border bg-muted text-muted-foreground px-1.5 py-0.5 text-sm font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none overflow-hidden",
+  "inline-flex items-center justify-center rounded-full border border-border bg-muted text-muted-foreground px-2.5 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none overflow-hidden",
   {
     variants: {
       variant: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-3 border py-3",
+        "bg-card text-card-foreground flex flex-col gap-4 border py-4 rounded-lg",
         className,
       )}
       {...props}
@@ -20,7 +20,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-3",
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-4 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-4",
         className,
       )}
       {...props}
@@ -65,7 +65,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-content"
-      className={cn("px-3", className)}
+      className={cn("px-4", className)}
       {...props}
     />
   );
@@ -75,7 +75,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("flex items-center px-3 [.border-t]:pt-3", className)}
+      className={cn("flex items-center px-4 [.border-t]:pt-4", className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
Transformed the app's visual language from brutalist black/white to a refined, editorial aesthetic matching the Literal Club reference design. Swapped typeface to Hanken Grotesk, softened the palette to warm monochrome, and dramatically increased whitespace throughout.

## Key Changes
- **Typography**: Hanken Grotesk replaces IBM Plex Sans for more distinctive, editorial character
- **Color palette**: Softened from pure black/white to warm near-blacks (#1A1A1A) and lighter grays with improved contrast hierarchy
- **Spacing**: Increased headers, sidebar, padding, and grid gaps to create intentionally sparse, breathing layout
- **Border radius**: Changed from 0px to 8px for subtle softness; badges now pill-shaped
- **Typography weights**: Lighter headings (font-medium) for refined, less authoritative tone

## Test Plan
- [ ] Verify light and dark modes render correctly with new color tokens
- [ ] Check header and sidebar layout at mobile, tablet, and desktop sizes
- [ ] Review book grid density and whitespace on library page
- [ ] Confirm collections page uses consistent spacing and styling
- [ ] Test that badges and cards display with updated styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)