### PR TITLE
Fix Electron auto-login to not show login window

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -40,11 +40,19 @@ export default function LoginPage() {
     defaultValues: { email: "", password: "" },
   });
 
-  // Desktop mode bypass: redirect to library immediately
+  // Desktop mode bypass: auto-login as admin@localhost and redirect
   useEffect(() => {
-    if (process.env.NEXT_PUBLIC_ALEX_DESKTOP === 'true') {
-      router.replace('/library');
+    async function autoLogin() {
+      if (process.env.NEXT_PUBLIC_ALEX_DESKTOP === 'true') {
+        await signIn("credentials", {
+          email: "admin@localhost",
+          password: "admin123",
+          redirect: false,
+        });
+        router.replace('/library');
+      }
     }
+    autoLogin();
   }, [router]);
 
   async function onSubmit({ email, password }: LoginValues) {

--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -85,6 +85,10 @@ async function desktopSession() {
   };
 }
 
-export const authSession = process.env.ALEX_DESKTOP === 'true'
-  ? desktopSession
-  : nextAuthResult.auth;
+// Dynamic auth session that checks ALEX_DESKTOP at runtime
+export async function authSession() {
+  if (process.env.ALEX_DESKTOP === 'true') {
+    return desktopSession();
+  }
+  return nextAuthResult.auth();
+}


### PR DESCRIPTION
Make authSession check ALEX_DESKTOP at runtime instead of module load time, ensuring the desktop session bypass always works in Electron context. This prevents the login window from appearing when launching the Electron app. Add auto-login logic to the login page as a safety net.

## Changes
- Modified `authSession` from a static assignment to a dynamic function that checks the environment variable on every call
- Enhanced login page to auto-login as admin@localhost when in Electron mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)