### PR TITLE
Require lint, build, and test checks for PR merges

### DIFF
--- a/docs/product/testing/PLAN.md
+++ b/docs/product/testing/PLAN.md
@@ -348,13 +348,16 @@ Each step is independently shippable and testable locally before adding CI.
 
 ## PR Required Checks (Phase 8)
 
-Main branch protection is configured so that PRs cannot merge until the required web E2E check passes.
+Main branch protection is configured so that PRs cannot merge until all required checks pass.
 
 ### Required checks
 
 The required status checks are:
 
 - `e2e-web`
+- `lint`
+- `build`
+- `test`
 
 Windows E2E checks are currently disabled and are not required for merge.
 Linux and macOS Electron E2E jobs still run in CI, but they are not required checks for merge.
@@ -381,7 +384,10 @@ gh api -X PUT repos/jamesacklin/alex/branches/main/protection --input - <<'JSON'
   "required_status_checks": {
     "strict": true,
     "contexts": [
-      "e2e-web"
+      "e2e-web",
+      "lint",
+      "build",
+      "test"
     ]
   },
   "enforce_admins": false,


### PR DESCRIPTION
## Summary
- require `lint`, `build`, and `test` status checks for merges to `main`
- keep existing required `e2e-web` check
- update `docs/product/testing/PLAN.md` to document the expanded required-check set

## Applied GitHub settings
- `required_status_checks.contexts`: `e2e-web`, `lint`, `build`, `test`
- `required_status_checks.strict`: `true`
- `required_pull_request_reviews.required_approving_review_count`: `0`
