### PR TITLE
Harden watcher for zero-byte ingest races

### DIFF
--- a/watcher/handleAdd.ts
+++ b/watcher/handleAdd.ts
@@ -18,6 +18,10 @@ export async function handleAdd(filePath: string) {
     const ext = path.extname(filePath).toLowerCase();
     const fileType = ext === ".pdf" ? "pdf" : "epub";
     const fileSize = fs.statSync(filePath).size;
+    if (fileSize === 0) {
+      log(`[SKIP] Zero-byte file (waiting for write): ${filePath}`);
+      return;
+    }
     const fileHash = computeHash(filePath);
 
     // Skip duplicates — same content already tracked


### PR DESCRIPTION
This updates watcher ingest to avoid indexing zero-byte files during copy/write operations. handleChange now retries untracked change events via handleAdd instead of warning-only, which recovers files that were skipped during transient states. It also skips zero-byte change events so temporary truncation does not produce bad metadata updates or duplicate-hash cascades.