### PR TITLE
Speed up Docker release builds

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -67,8 +67,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=docker-release
+          cache-to: type=gha,scope=docker-release,mode=min
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,8 @@ WORKDIR /app
 
 # Install dependencies with pnpm store cache mount for faster installs
 COPY package.json pnpm-lock.yaml .pnpm-build-approval.yaml ./
-RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+RUN --mount=type=cache,id=pnpm-${TARGETPLATFORM},target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile
-
-# Build native module (better-sqlite3)
-RUN cd node_modules/.pnpm/better-sqlite3@12.6.2/node_modules/better-sqlite3 && npm run build-release
 
 # Copy source and build Next.js
 COPY . .


### PR DESCRIPTION
## Summary
- remove the explicit `better-sqlite3` source compile step from the Dockerfile so release builds do not pay a guaranteed cross-arch native compile cost
- scope Buildx GHA cache entries to this workflow (`scope=docker-release`)
- switch GHA cache export from `mode=max` to `mode=min` to reduce cache export/upload time on release runners
- split pnpm cache mounts by target platform to reduce cross-arch contention during parallel multi-platform builds

## Why
Recent release runs are spending most of their time in arm64 emulated native compilation and cache export. These changes target those hotspots without changing release triggers or published tags.

## Validation
- verified workflow and Dockerfile diffs only
- did not run local Docker build in this environment (Docker CLI is unavailable here)
