### PR TITLE
Fix Docker release Rust binary copy step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,8 @@ RUN --mount=type=cache,id=cargo-registry-${TARGETPLATFORM},target=/usr/local/car
     --mount=type=cache,id=cargo-git-${TARGETPLATFORM},target=/usr/local/cargo/git \
     --mount=type=cache,id=cargo-cache-${TARGETPLATFORM},target=/usr/local/cargo/cache \
     --mount=type=cache,id=watcher-target-${TARGETPLATFORM},target=/app/watcher-rs/target \
-    cargo build --manifest-path watcher-rs/Cargo.toml --release --locked
-
-RUN set -eux; \
+    set -eux; \
+    cargo build --manifest-path watcher-rs/Cargo.toml --release --locked; \
     mkdir -p /out; \
     cp watcher-rs/target/release/watcher-rs /out/watcher-rs; \
     chmod +x /out/watcher-rs; \


### PR DESCRIPTION
This PR fixes the Docker release build failure introduced by the target cache mount. The Rust build and binary copy now run in the same cache-mounted Docker layer so watcher-rs/target/release/watcher-rs is available when copied to /out. This addresses the failure seen in Actions run 22229250069 for both amd64 and arm64 jobs. No workflow structure changes are included in this PR.