### PR TITLE
fix: bind Next.js to 0.0.0.0 for Docker ingress

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ EXPOSE 3000
 CMD ["sh", "-c", \
   "export WATCHER_RS_BIN=/app/watcher-rs/watcher-rs; \
    export LD_LIBRARY_PATH=/app/watcher-rs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}; \
+   export HOSTNAME=0.0.0.0; \
    pnpm db:push && pnpm db:seed && \
    /app/watcher-rs/watcher-rs & \
    exec node .next/standalone/server.js"]


### PR DESCRIPTION
## Summary

Set HOSTNAME=0.0.0.0 when running the Next.js standalone server in Docker. This makes the server listen on all interfaces instead of just the container hostname, fixing HTTP ingress from outside the container.

## Context

Production container logs showed the server binding to the container hostname (e.g., http://98073f3644a7:3000) instead of 0.0.0.0, making it unreachable externally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)