### PR TITLE
fix: serve Next.js static assets correctly in standalone Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,13 +57,17 @@ WORKDIR /app
 
 COPY --from=node-builder /app/package.json .
 COPY --from=node-builder /app/node_modules ./node_modules
-COPY --from=node-builder /app/.next ./.next
-COPY --from=node-builder /app/public ./public
 COPY --from=node-builder /app/scripts ./scripts
-
 COPY --from=node-builder /app/next.config.ts .
 COPY --from=node-builder /app/tsconfig.json .
 COPY --from=node-builder /app/src/lib/db ./src/lib/db
+
+# Standalone server + its bundled node_modules
+COPY --from=node-builder /app/.next/standalone ./.next/standalone
+# Static assets must live inside the standalone dir so server.js can serve them
+COPY --from=node-builder /app/.next/static ./.next/standalone/.next/static
+# Public assets likewise
+COPY --from=node-builder /app/public ./.next/standalone/public
 
 COPY --from=rust-builder /out ./watcher-rs
 


### PR DESCRIPTION
## Summary

- Replaces the blanket `.next` directory copy with targeted copies of only `.next/standalone` (the minimal server) and `.next/static` placed inside it at `.next/standalone/.next/static`
- Copies `public` into `.next/standalone/public` for the same reason

## Context

The Next.js standalone server resolves `_next/static` relative to `server.js`, not the working directory. Previously static assets were at `/app/.next/static` but the server expected them at `/app/.next/standalone/.next/static`, causing 404s for all JS, CSS, and font files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)