### PR TITLE
Show server URL on Users page; clean up Electron admin settings

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, dialog, ipcMain, nativeImage } from 'electron';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as net from 'net';
 import { spawn, ChildProcess, spawnSync } from 'child_process';
@@ -1021,6 +1022,20 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('get-app-version', () => {
     return app.getVersion();
+  });
+
+  ipcMain.handle('get-local-ips', () => {
+    const interfaces = os.networkInterfaces();
+    const urls: string[] = [];
+    for (const addrs of Object.values(interfaces)) {
+      if (!addrs) continue;
+      for (const addr of addrs) {
+        if (addr.family === 'IPv4' && !addr.internal) {
+          urls.push(`http://${addr.address}:${PORT}`);
+        }
+      }
+    }
+    return urls;
   });
 
   ipcMain.handle('get-library-path', () => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -10,6 +10,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getAppVersion: () => ipcRenderer.invoke('get-app-version'),
   getLibraryPath: () => ipcRenderer.invoke('get-library-path'),
   getStorageMode: () => ipcRenderer.invoke('get-storage-mode'),
+  getLocalIps: () => ipcRenderer.invoke('get-local-ips'),
   getS3Config: () => ipcRenderer.invoke('get-s3-config'),
   saveS3Config: (config: Record<string, unknown>) => ipcRenderer.invoke('save-s3-config', config),
   switchToLocalStorage: () => ipcRenderer.invoke('switch-to-local-storage'),

--- a/src/app/(dashboard)/admin/general/general-settings-client.tsx
+++ b/src/app/(dashboard)/admin/general/general-settings-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { signOut } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 
@@ -13,6 +14,7 @@ export function GeneralSettingsClient({
   displayName,
   email,
 }: GeneralSettingsClientProps) {
+  const router = useRouter();
   const [isElectron, setIsElectron] = useState(
     process.env.NEXT_PUBLIC_ALEX_DESKTOP === "true",
   );
@@ -21,8 +23,11 @@ export function GeneralSettingsClient({
     const electron = typeof window !== "undefined" && !!window.electronAPI;
     if (electron) {
       setIsElectron(true);
+      router.replace("/admin/users");
     }
-  }, []);
+  }, [router]);
+
+  if (isElectron) return null;
 
   return (
     <div className="space-y-8">
@@ -35,17 +40,15 @@ export function GeneralSettingsClient({
       </div>
 
       {/* Logout */}
-      {!isElectron && (
-        <div>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => signOut({ redirectTo: "/login" })}
-          >
-            Log out
-          </Button>
-        </div>
-      )}
+      <div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => signOut({ redirectTo: "/login" })}
+        >
+          Log out
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/app/(dashboard)/admin/users/page.tsx
+++ b/src/app/(dashboard)/admin/users/page.tsx
@@ -26,11 +26,19 @@ export default async function UsersPage() {
     `
   );
 
+  // For web/docker deployments, expose the configured server URL.
+  // In Electron mode, the client-side component fetches LAN IPs via electronAPI.
+  const isElectron = process.env.ALEX_DESKTOP === "true";
+  const webServerUrl = isElectron
+    ? null
+    : (process.env.AUTH_URL ?? process.env.NEXTAUTH_URL ?? null);
+
   return (
     <UsersTable
       users={allUsers}
       currentUserId={session?.user?.id ?? ""}
       actionsContainerId="settings-actions"
+      webServerUrl={webServerUrl}
     />
   );
 }

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -18,6 +18,7 @@ export interface ElectronAPI {
   getAppVersion: () => Promise<string>;
   getLibraryPath: () => Promise<string>;
   getStorageMode: () => Promise<'local' | 's3'>;
+  getLocalIps: () => Promise<string[]>;
   getS3Config: () => Promise<S3Config | null>;
   saveS3Config: (config: S3Config) => Promise<{ success: boolean; error?: string }>;
   switchToLocalStorage: () => Promise<{ success: boolean; error?: string }>;


### PR DESCRIPTION
- Electron: add `get-local-ips` IPC handler (os.networkInterfaces) and
  expose via preload/electronAPI so the Users page can display LAN URLs
  that other devices can use to reach the server (http://<ip>:3210)
- Web/Docker: pass AUTH_URL / NEXTAUTH_URL from the server component to
  UsersTable so admins see the configured server address
- UsersTable: render a "Server URL" panel above the user list with
  one-click copy buttons for each address
- Electron general settings: redirect to /admin/users (the admin's
  natural home in the desktop app) and drop the now-unreachable logout
  branch so the component stays minimal

https://claude.ai/code/session_01PS5ZSkwE6kLBpKq3px2Cir