### PR TITLE
Simplify Users table and improve collection sharing with relay

### DIFF
--- a/src/app/(dashboard)/admin/users/page.tsx
+++ b/src/app/(dashboard)/admin/users/page.tsx
@@ -26,19 +26,11 @@ export default async function UsersPage() {
     `
   );
 
-  // For web/docker deployments, expose the configured server URL.
-  // In Electron mode, the client-side component fetches LAN IPs via electronAPI.
-  const isElectron = process.env.ALEX_DESKTOP === "true";
-  const webServerUrl = isElectron
-    ? null
-    : (process.env.AUTH_URL ?? process.env.NEXTAUTH_URL ?? null);
-
   return (
     <UsersTable
       users={allUsers}
       currentUserId={session?.user?.id ?? ""}
       actionsContainerId="settings-actions"
-      webServerUrl={webServerUrl}
     />
   );
 }

--- a/src/app/(dashboard)/admin/users/users-table.tsx
+++ b/src/app/(dashboard)/admin/users/users-table.tsx
@@ -100,12 +100,10 @@ export default function UsersTable({
   users,
   currentUserId,
   actionsContainerId,
-  webServerUrl,
 }: {
   users: UserRow[];
   currentUserId: string;
   actionsContainerId?: string;
-  webServerUrl?: string | null;
 }) {
   const router = useRouter();
   const [addOpen, setAddOpen] = useState(false);
@@ -118,7 +116,6 @@ export default function UsersTable({
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [deleteEmail, setDeleteEmail] = useState("");
   const [actionsContainer, setActionsContainer] = useState<HTMLElement | null>(null);
-  const [localIps, setLocalIps] = useState<string[]>([]);
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
   const [tunnelEnabled, setTunnelEnabled] = useState(false);
   const [tunnelUrl, setTunnelUrl] = useState("");
@@ -130,9 +127,6 @@ export default function UsersTable({
   }, [actionsContainerId]);
 
   useEffect(() => {
-    if (typeof window !== "undefined" && window.electronAPI?.getLocalIps) {
-      window.electronAPI.getLocalIps().then(setLocalIps).catch(() => {});
-    }
     if (typeof window !== "undefined" && window.electronAPI?.getTunnelStatus) {
       window.electronAPI.getTunnelStatus().then((status: { enabled: boolean; url: string }) => {
         setTunnelEnabled(status.enabled);
@@ -282,7 +276,6 @@ export default function UsersTable({
   }
 
   const isElectron = typeof window !== "undefined" && !!window.electronAPI?.getTunnelStatus;
-  const serverUrls = localIps.length > 0 ? localIps : webServerUrl ? [webServerUrl] : [];
 
   return (
     <TooltipProvider>
@@ -296,39 +289,13 @@ export default function UsersTable({
             </div>
           )}
 
-      {serverUrls.length > 0 && (
-        <div className="mb-6 rounded-lg border border-border bg-muted/30 p-4 space-y-2">
-          <p className="text-sm font-medium">Server URL</p>
-          <p className="text-xs text-muted-foreground">
-            Share this address so others can access the server from their devices.
-          </p>
-          <div className="space-y-1.5">
-            {serverUrls.map((url) => (
-              <div key={url} className="flex items-center gap-2">
-                <code className="flex-1 rounded bg-background px-2 py-1 text-xs font-mono border border-border">
-                  {url}
-                </code>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => copyUrl(url)}
-                  className="shrink-0 text-xs h-7"
-                >
-                  {copiedUrl === url ? "Copied!" : "Copy"}
-                </Button>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
       {isElectron && (
         <div className="mb-6 rounded-lg border border-border bg-muted/30 p-4 space-y-3">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm font-medium">Public Access</p>
+              <p className="text-sm font-medium">Public Access (Relay)</p>
               <p className="text-xs text-muted-foreground">
-                Expose your library at a public URL so anyone with the link can access it.
+                Enable this to expose your library at a stable public URL. This is required for sharing collections with people outside your local network.
               </p>
             </div>
             <Button

--- a/src/app/(dashboard)/collections/[id]/collection-detail-client.tsx
+++ b/src/app/(dashboard)/collections/[id]/collection-detail-client.tsx
@@ -15,6 +15,12 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { BookCard, type Book } from "@/components/library/BookCard";
 import { Share2, Copy, Check } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface CollectionResponse {
   collection: {
@@ -73,6 +79,9 @@ export default function CollectionDetailClient() {
   const [shareError, setShareError] = useState<string | null>(null);
   const [isEnablingShare, setIsEnablingShare] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [isElectron, setIsElectron] = useState(false);
+  const [tunnelEnabled, setTunnelEnabled] = useState(false);
+  const [tunnelUrl, setTunnelUrl] = useState("");
 
   // Pagination state
   const [allBooks, setAllBooks] = useState<Book[]>([]);
@@ -96,6 +105,16 @@ export default function CollectionDetailClient() {
         console.error("Failed to fetch now reading books:", err);
       });
   }, [collectionId]);
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.electronAPI?.getTunnelStatus) {
+      setIsElectron(true);
+      window.electronAPI.getTunnelStatus().then((status: { enabled: boolean; url: string }) => {
+        setTunnelEnabled(status.enabled);
+        setTunnelUrl(status.url || "");
+      }).catch(() => {});
+    }
+  }, []);
 
   const form = useForm<EditValues>({
     resolver: zodResolver(editSchema),
@@ -280,10 +299,15 @@ export default function CollectionDetailClient() {
     }
   }
 
+  function getShareBaseUrl(): string {
+    if (isElectron && tunnelUrl) return tunnelUrl.replace(/\/$/, "");
+    return typeof window !== "undefined" ? window.location.origin : "";
+  }
+
   async function onCopyShareLink() {
     if (!collection?.collection.shareToken) return;
 
-    const shareUrl = `${window.location.origin}/shared/${collection.collection.shareToken}`;
+    const shareUrl = `${getShareBaseUrl()}/shared/${collection.collection.shareToken}`;
 
     try {
       await navigator.clipboard.writeText(shareUrl);
@@ -372,7 +396,7 @@ export default function CollectionDetailClient() {
                 <Input
                   readOnly
                   aria-label="Share URL"
-                  value={`${typeof window !== "undefined" ? window.location.origin : ""}/shared/${collection.collection.shareToken}`}
+                  value={`${getShareBaseUrl()}/shared/${collection.collection.shareToken}`}
                   className="flex-1 min-w-0 font-mono text-sm"
                 />
                 <Button variant="outline" onClick={onCopyShareLink} className="shrink-0">
@@ -393,6 +417,22 @@ export default function CollectionDetailClient() {
                 Stop Sharing
               </Button>
             </>
+          ) : isElectron && !tunnelEnabled ? (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>
+                    <Button variant="outline" disabled>
+                      <Share2 className="h-4 w-4 mr-2" />
+                      Share
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  Enable Public Access (Relay) in Admin settings to share collections.
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           ) : (
             <Button variant="outline" onClick={() => setShareOpen(true)}>
               <Share2 className="h-4 w-4 mr-2" />


### PR DESCRIPTION
## Summary
- Remove Server URL/IP section from admin Users table to reduce clutter
- Update relay section with clearer title and description explaining why users should enable it
- Collection sharing now uses relay URL as the share base in Electron mode
- Disable Share button in Electron when relay is not enabled, with helpful tooltip

This streamlines the admin interface to focus on the relay feature, which is the most important for external access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)