### PR TITLE
Use pinned pnpm in release workflows

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -205,8 +205,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -261,8 +259,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -164,8 +162,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary\n\n- remove stale pnpm 9 overrides from Electron release jobs\n- remove the same overrides from dev build jobs\n- let pnpm/action-setup use the repository's pinned pnpm 10.33.2 version\n\n## Why\n\nThe v0.6.2 Electron release workflow failed during setup because pnpm/action-setup rejected the conflicting workflow and package.json versions.\n\n## Validation\n\n- verified all four hardcoded pnpm 9 overrides are removed\n- git diff --check passes\n- PR #112 CI passed with pnpm 10.33.2