### PR TITLE
Prevent double-compression in tunnel responses

### DIFF
--- a/alex-relay/src/index.ts
+++ b/alex-relay/src/index.ts
@@ -247,7 +247,13 @@ export class Tunnel extends DurableObject<Env> {
     }
 
     try {
-      pending.resolve(new Response(stream.readable, { status, headers }));
+      pending.resolve(new Response(stream.readable, {
+        status,
+        headers,
+        // The tunnel forwards the origin bytes verbatim. Without this,
+        // Workers compresses an already-compressed response a second time.
+        encodeBody: "manual",
+      }));
     } catch (error) {
       if (body.timeout !== undefined) clearTimeout(body.timeout);
       this.pending.delete(requestId);


### PR DESCRIPTION
## Summary\n\n- mark relayed response bodies as pre-compressed with Cloudflare's `encodeBody: manual` option\n- prevent the Workers runtime from applying a second compression layer\n\n## Root cause\n\nThe tunnel forwards origin bytes verbatim, including gzip-compressed Next.js responses. Cloudflare treated those bytes as uncompressed and compressed them again, so browsers decoded one layer and received another gzip stream instead of HTML.\n\n## Validation\n\n- Worker typecheck passes\n- 6 Worker tests pass\n- repository lint passes\n- deployed Worker version `217693ea-f902-46a5-b922-2a5f860a64d6`\n- browser-style compressed fetch now decodes to HTML\n- 12 concurrent live requests returned HTTP 200 with valid HTML